### PR TITLE
Fixes links with no rel attribute; removes old Go versions from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 language: go
 
 go:
-  - 1.5
   - 1.6
+  - 1.7
   - tip
-
-install:
-  - ./script/bootstrap
-
-script:
-  - ./script/test
-#  - ./script/lint
-

--- a/README.mkd
+++ b/README.mkd
@@ -1,6 +1,6 @@
 # Golang Link Header Parser
 
-Library for parsing HTTP Link headers. Requires Go 1.2 or higher.
+Library for parsing HTTP Link headers. Requires Go 1.6 or higher.
 
 Docs can be found on [the GoDoc page](https://godoc.org/github.com/tomnomnom/linkheader).
 

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func Parse(raw string) Links {
 
 		}
 
-		if link.URL != "" && link.Rel != "" {
+		if link.URL != "" {
 			links = append(links, link)
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -45,6 +45,20 @@ func TestEmpty(t *testing.T) {
 	}
 }
 
+// Although not often seen in the wild, the grammar in RFC 5988 suggests that it's
+// valid for a link header to have nothing but a URL.
+func TestNoRel(t *testing.T) {
+	links := Parse("<http://example.com>")
+
+	if len(links) != 1 {
+		t.Fatalf("Length of links should be 1, but was %d", len(links))
+	}
+
+	if links[0].URL != "http://example.com" {
+		t.Errorf("URL should be http://example.com, but was %s", links[0].URL)
+	}
+}
+
 func TestLinkMethods(t *testing.T) {
 	header := "<https://api.github.com/user/9287/repos?page=1&per_page=100>; rel=\"prev\"; pet=\"cat\""
 	links := Parse(header)


### PR DESCRIPTION
Hi there!

Thanks for your issue and PR! Things mostly look good, but there's a couple of minor things to sort before I merge:

1. The Travis CI build is failing under Go 1.5 (not at all your fault!)
2. On reading your PR and [RFC 5988](https://tools.ietf.org/html/rfc5988) more closely, it looks like the `rel` param is not required, so I've removed your check for it being empty, and added a check to make sure that edge case is covered.

Thanks again for your contribution! If you merge this PR then I'll get yours merged :)